### PR TITLE
Turn ProxyRequests off

### DIFF
--- a/templates/default/loadBalancer/httpd24.conf.erb
+++ b/templates/default/loadBalancer/httpd24.conf.erb
@@ -348,7 +348,7 @@ AddDefaultCharset UTF-8
 EnableSendfile on
 
 <IfModule mod_proxy.c>
-  ProxyRequests On
+  ProxyRequests Off
   ProxyPassReverse / balancer://alf/
 
   ProxyPass /balancer-manager !


### PR DESCRIPTION
It is not necessary to turn ProxyRequests on in order to configure a reverse proxy.